### PR TITLE
Typo fix

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,7 +3,6 @@ extends =
     http://svn.plone.org/svn/collective/buildout/plonetest/test-4.x.cfg
 # We test with versions from Plone 4.1
     http://good-py.appspot.com/release/dexterity/1.1?plone=4.1
-package-name = example.conference
 # We will leave 'instance' and 'test' to check the default stuff and
 # extra parts 'datagridinstance' and 'datagridtest' for the funky
 # stuff with extra packages.  This currently needs extra checkouts.


### PR DESCRIPTION
"package-name = ..." in buildout.cfg > [buildout] is duplicated
